### PR TITLE
The source :rugygems is deprecated, replaced with https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
minus deprecation warning
