### PR TITLE
add restrictions to SlugValidator

### DIFF
--- a/lib/slug_validator.rb
+++ b/lib/slug_validator.rb
@@ -1,7 +1,17 @@
 class SlugValidator < ActiveModel::EachValidator
+  MAX_SLUG_LENGTH = 250
+  MIN_SLUG_LENGTH = 1
+
   def validate_each(record, attribute, value)
-    unless value =~ /^[\w-]+$/i
+    unless self.class.valid?(value)
       record.errors.add(attribute, :slug, options.merge(:value => value))
     end
-  end                  
+  end
+
+  class << self
+
+    def valid?(value)
+      value.to_s =~ /^[a-zA-Z_]{#{MIN_SLUG_LENGTH},#{MAX_SLUG_LENGTH}}$/i
+    end
+  end
 end

--- a/test/lib/slug_validator_test.rb
+++ b/test/lib/slug_validator_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class SlugValigatorTest < Test::Unit::TestCase
+  def test_valid
+    valid_slugs = [
+      'page',
+      'hello_world'
+    ]
+
+    valid_slugs.each do |slug|
+      assert SlugValidator.valid?(slug), "slug #{slug} not valid!"
+    end
+  end
+
+  def test_invalid
+    invalid_slugs = [
+      '123_page',
+      '',
+      '!!!!slug',
+      too_big_slug
+    ]
+
+    invalid_slugs.each do |slug|
+      assert !SlugValidator.valid?(slug), "slug #{slug} valid!"
+    end
+  end
+
+  private
+    def too_big_slug
+      chars = [('a'..'z'), ('A'..'Z')].map { |r| r.to_a }.flatten
+      chars << '_'
+      too_big_value = SlugValidator::MAX_SLUG_LENGTH + 1
+
+      (0...too_big_value).map{ chars[rand(chars.length)] }.join
+    end
+end


### PR DESCRIPTION
The restrictions about max slug length (set to 250) and contains characters (only a-z, A-Z and underscore) has been added to the SlugValidator
