### PR TITLE
Dynamic length validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,20 @@ where `<validator_underscore>` is an underscored, lowercase form from the valida
 
 Because this is the successor of ActiveModel::Validations::LengthValidator
 validator, it inherits all the options of the latter, such as `:is`, `:minimum`,
-`:maximum`, etc. Another option, which you may be interested in is `:select` option,
+`:maximum`, etc.
+Another feature is the ability to send lambda or symbol as value, like this:
+``` ruby
+  validates :field, association_length: { maximum: -> (record) { record.max } }
+  validates :field2, association_length: { maximum: -> { 3 } }
+  validates :field3, association_length: { maximum: :max }
+```
+
+Yet another option, which you may be interested in is `:select` option,
 which allows you to filter the collection of the associated objects.
+
+``` ruby
+  validates :employees, :association_length => { :minimum => 1, :select => :employees_filter }
+```
 
 ## Examples
 

--- a/lib/association_length_validator.rb
+++ b/lib/association_length_validator.rb
@@ -1,9 +1,47 @@
+# -*- coding: utf-8 -*-
 class AssociationLengthValidator < ActiveModel::Validations::LengthValidator
+
   def validate_each(record, attribute, value)
-    value = value.reject(&:marked_for_destruction?)
+    value = value.reject(&:marked_for_destruction?) if value.respond_to?(:reject)
     value = select_items(record, value, options[:select]) if options[:select]
 
-    super(record, attribute, value)
+    value = tokenize(value)
+    value_length = value.respond_to?(:length) ? value.length : value.to_s.length
+    errors_options = options.except(*RESERVED_OPTIONS)
+
+    CHECKS.each do |key, validity_check|
+      next unless check_value = options[key]
+
+      check_value = evaluate_options_value record, check_value
+
+      if !value.nil? || skip_nil_check?(key)
+        next if value_length.send(validity_check, check_value)
+      end
+
+      errors_options[:count] = check_value
+
+      default_message = options[MESSAGES[key]]
+      errors_options[:message] ||= default_message if default_message
+
+      record.errors.add(attribute, MESSAGES[key], errors_options)
+    end
+  end
+
+  def check_validity!
+    keys = CHECKS.keys & options.keys
+
+    if keys.empty?
+      raise ArgumentError, 'Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.'
+    end
+
+    keys.each do |key|
+      value = options[key]
+
+      unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY ||
+        value.is_a?(Proc) || value.is_a?(Symbol) || value.is_a?(String)
+        raise ArgumentError, ":#{key} must be a nonnegative Integer or Infinity, or String, Symbol or Proc"
+      end
+    end
   end
 
   private
@@ -20,6 +58,27 @@ class AssociationLengthValidator < ActiveModel::Validations::LengthValidator
       items.select(&select_expr)
     else
       items
+    end
+  end
+
+  def evaluate_options_value(record, check_value)
+    case check_value
+    when Symbol, String
+      if record.respond_to?(check_value)
+        record.send(check_value)
+      else
+        raise ArgumentError, "Missing instance method #{record.class.name}##{check_value}"
+      end
+    when Proc
+      raise ArgumentError, "Invalid arity: may be zero or one arguments. Current arguments count: #{check_value.arity}" if check_value.arity > 1
+
+      if check_value.arity == 1
+        check_value.call(record)
+      else
+        check_value.call
+      end
+    else
+      check_value
     end
   end
 end

--- a/lib/validates/version.rb
+++ b/lib/validates/version.rb
@@ -1,3 +1,3 @@
 module Validates
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/test/lib/association_length_validator_test.rb
+++ b/test/lib/association_length_validator_test.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+require 'test_helper'
+
+class AssociationLengthValidatorTest < Minitest::Test
+
+  def test_valid
+    model = AssociatedModel.new
+    [:field, :field2, :field3].each do |field|
+      model.send("#{field}=", [1,2,3].map { AssociatedModel.new })
+    end
+
+    model.max = 3
+
+    assert model.valid?
+  end
+
+  def test_invalid
+    model = AssociatedModel.new
+    [:field, :field2, :field3].each do |field|
+      model.send("#{field}=", [1,2,3,4].map { AssociatedModel.new })
+    end
+
+    model.max = 3
+
+    refute model.valid?
+  end
+end

--- a/test/support/associated_model.rb
+++ b/test/support/associated_model.rb
@@ -1,0 +1,16 @@
+class AssociatedModel
+  include ActiveModel::Validations
+
+  attr_accessor :field
+  attr_accessor :field2
+  attr_accessor :field3
+  attr_accessor :max
+
+  validates :field, association_length: { maximum: lambda { |record| record.max } }
+  validates :field2, association_length: { maximum: lambda { 3 } }
+  validates :field3, association_length: { maximum: :max }
+
+  def marked_for_destruction?
+    false
+  end
+end


### PR DESCRIPTION
Теперь в associated_length_validator можно передавать лямбду или символ, как 

  validates :field, association_length: { maximum: -> (record) { record.max } }
  validates :field2, association_length: { maximum: -> { 3 } }
  validates :field3, association_length: { maximum: :max }

UPD. пофиксил тесты для ruby1.9.3