### PR TITLE
Persistence validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - rbx
   - jruby
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile.activemodel-3.0
-  - gemfiles/Gemfile.activemodel-4.0
 matrix:
   allow_failures:
     - rvm: rbx

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Collection of useful custom validators for Rails applications, including:
 - AbsolutePathValidator
 - UriComponentValidator
 - ColorValidator
+- PersistenceValidator
 - EanValidator ([EAN-8 & EAN-13](http://en.wikipedia.org/wiki/International_Article_Number_(EAN)))
 
 **Note** InnValidator and other Russian specific validators could be found at [validates_russian](https://github.com/asiniy/validates_russian) gem

--- a/lib/persistence_validator.rb
+++ b/lib/persistence_validator.rb
@@ -1,0 +1,8 @@
+class PersistenceValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    attribute_changes = record.changes[attribute.to_s]
+    if attribute_changes.present? && attribute_changes[0].present?
+      record.errors.add(attribute, :changed, options.merge(value: value))
+    end
+  end
+end

--- a/lib/validates.rb
+++ b/lib/validates.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/enumerable'
 require 'active_model'
 
-[:absolute_path, :association_length, :color, :ean, :email, :inn, :ip, :money, :slug, :uri_component, :url].each do |name|
+[:absolute_path, :association_length, :color, :ean, :email, :inn, :ip, :money, :persistence, :slug, :uri_component, :url].each do |name|
   autoload :"#{name.to_s.classify}Validator", "#{name}_validator"
 end
 

--- a/test/lib/persistence_validator_test.rb
+++ b/test/lib/persistence_validator_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class PersistenceValidatorTest < ValidatorTest
+
+  def test_valid
+    DirtyModel.validates :field, persistence: true
+    model = DirtyModel.new
+    model.field = '   '
+    assert model.valid?
+
+    model.field = 'fill it with value'
+    assert model.valid?
+
+    model.field = 'another unpredictable change'
+    assert model.valid?
+  end
+end

--- a/test/support/dirty_model.rb
+++ b/test/support/dirty_model.rb
@@ -1,0 +1,20 @@
+class DirtyModel
+  include ActiveModel::Validations
+  include ActiveModel::Dirty
+
+  define_attribute_methods :field
+
+  def field
+    @field
+  end
+
+  def field=(value)
+    unless value == @field
+      field_will_change!
+      changes_applied
+      clear_changes_information
+    end
+
+    @field = value
+  end
+end

--- a/validates.gemspec
+++ b/validates.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.rdoc_options      = %w(--line-numbers --inline-source --title validates --main README.md)
   s.extra_rdoc_files  = %w(README.md LICENSE CONTRIBUTING.md CHANGELOG.md)
 
-  s.add_dependency "activemodel", [">= 3.0.0"]
-  s.add_dependency "activesupport", [">= 3.0.0"]
+  s.add_dependency "activemodel", [">= 4.2.0"]
+  s.add_dependency "activesupport", [">= 4.2.0"]
 end


### PR DESCRIPTION
As rails is near 5.0.0, we need to move forward and remove deprecated versions of ruby & activemodel. Btw, this validator wouldn't be support on rails < 4.2.1 because of buggy and dirty behavior & code of `ActiveModel::Dirty`:  http://apidock.com/rails/v4.2.1/ActiveModel/Dirty

`1.0.1`, please, with note to users of 3.x of activemodel & 1.9 of ruby :)